### PR TITLE
if inflate() fails, free the stream instead of leaking it

### DIFF
--- a/ctfdump.c
+++ b/ctfdump.c
@@ -566,6 +566,7 @@ decompress(const char *buf, size_t size, off_t len)
 
 	if ((error = inflate(&stream, Z_FINISH)) != Z_STREAM_END) {
 		warnx("zlib inflate failed: %s", zError(error));
+		inflateEnd(&stream);
 		goto exit;
 	}
 


### PR DESCRIPTION
pointed out by guenther@openbsd.org while reviewing a separate diff
